### PR TITLE
Basic bone support + code comments.

### DIFF
--- a/spriter_imp/entity.lua
+++ b/spriter_imp/entity.lua
@@ -35,27 +35,29 @@ local utils = require("spriter_imp.utils")
 -- Exports --
 local M = {}
 
--- --
-local Animation = utils.FuncTable()
-
-Animation.mainline = mainline.LoadPass
-Animation.timeline = timeline.LoadPass
-
 --- DOCME
 -- @ptable entity
 function M.LoadPass (entity)
 	local entity_data = utils.NewLUT()
 
+  -- Extract data for animations (only type of child for entities)
 	for _, anim, aprops in utils.Children(entity) do
+	  -- Set properties from xml attributes: looping, loop_to, length
 		local anim_data = {
 			looping = aprops.looping, loop_to = aprops.loop_to or 0,
 			length = tonumber(aprops.length)
 		}
---assert(anim.name == "animation") ??
-		for _, aelem in utils.Children(anim) do
-			Animation(aelem, anim_data)
+    -- Iterate over children (one mainline, zero or many timelines)
+		for _, timeline_data in utils.Children(anim) do
+  		local anim_type = timeline_data.name
+      if (anim_type == 'mainline') then
+			  anim_data.mainline = mainline.LoadPass(timeline_data)
+		  elseif (anim_type == 'timeline') then
+		    local tl = timeline.LoadPass(timeline_data)
+      	utils.AddByID(anim_data, tl, timeline_data.properties)
+	    end
 		end
--- assert(anim._timeline)
+
 		utils.AddToLUT(entity_data, anim_data, aprops)
 	end
 
@@ -65,9 +67,16 @@ end
 --- DOCME
 -- @ptable data
 function M.Process (data)
--- assert(data._entities)
 	for _, entity_data in ipairs(data.entity) do
 		for _, anim_data in ipairs(entity_data) do
+
+		  local bone_refs = anim_data.mainline[1].bone_ref
+      local bone_table = {}
+    	for idx, bone_data in ipairs(bone_refs) do
+    	  bone_table[idx] = bone_data.timeline
+      end
+      anim_data.bone_table = bone_table
+
 			mainline.Process(data, anim_data)
 			timeline.Process(data, anim_data)
 		end

--- a/spriter_imp/mainline.lua
+++ b/spriter_imp/mainline.lua
@@ -53,33 +53,52 @@ end
 
 --
 function MainlineKey:object_ref (oprops)
+  local parent = oprops.parent
+   if parent then
+     parent = parent + 1
+   end
 	return {
 		key = utils.Index(oprops, "key"),
 		timeline = utils.Index(oprops, "timeline"),
+    parent = parent,
 		z_index = tonumber(oprops.z_index)
 	}
+end
+
+function MainlineKey:bone_ref (oprops)
+  local parent = oprops.parent
+  if parent then
+    parent = parent + 1
+  end
+ return {
+   key = utils.Index(oprops, "key"),
+   parent = parent,
+   timeline = utils.Index(oprops, "timeline"),
+ }
 end
 
 --- DOCME
 -- @ptable mainline
 -- @ptable animation
-function M.LoadPass (mainline, animation)
---assert(not animation.mainline)
+function M.LoadPass (mainline)
 	local mainline_data = {}
 
 	for _, key, kprops in utils.Children(mainline) do
-		local key_data = { time = tonumber(kprops.time) or 0 }
+		local key_data = { time = tonumber(kprops.time) or 0,
+		                    object_ref = {},
+		                    bone_ref = {} }
 --assert(key.id == _ - 1)?
 		for _, child, cprops in utils.Children(key) do
 			local object_data = MainlineKey(child, cprops)
-
-			utils.AddByID(key_data, object_data, cprops)
+		  -- Save object data to the appropriate table (bone_ref or object_ref list),
+			local table = key_data[child.name]
+			utils.AddByID(table, object_data, cprops)
 		end
 
 		utils.AddByID(mainline_data, key_data, kprops)
 	end
 
-	animation.mainline = mainline_data
+  return mainline_data
 end
 
 --- DOCME

--- a/spriter_imp/timeline.lua
+++ b/spriter_imp/timeline.lua
@@ -37,7 +37,8 @@ local M = {}
 local TimelineKey = utils.FuncTable()
 
 --
-function TimelineKey:bone (bprops)
+function TimelineKey:bone (bprops, object_type)
+  return object.LoadPass(bprops, object_type)
 end
 
 --
@@ -51,21 +52,26 @@ local UsageDefs = { box = "collision", point = "neither", entity = "display", sp
 --- DOCME
 -- @ptable timeline
 -- @ptable animation
-function M.LoadPass (timeline, animation)
+function M.LoadPass (timeline)
 	local timeline_data, tprops = {}, timeline.properties
 
 	--
 	local object_type, usage = tprops.object_type or "sprite"
 
 	if object_type ~= "sound" then
+    -- Get usage if the object type supports it
+    -- If not present, get default from UsageDefs
 		if object_type ~= "variable" then
 			usage = tprops.usage or UsageDefs[object_type]
 		end
 
+    -- Get name if this is not a sprite or sound
+    -- OR if this is a sprite with usage "collision" or "both"
 		if object_type ~= "sprite" or (usage == "collision" or usage == "both") then
 			timeline_data.name = tprops.name
 		end
 
+    -- Get variable type if this is a variable
 		if object_type == "variable" then
 			timeline_data.variable_type = tprops.variable_type or "string"
 		end
@@ -74,13 +80,11 @@ function M.LoadPass (timeline, animation)
 	timeline_data.object_type = object_type
 	timeline_data.usage = usage
 
-	--
+	-- Get the keys in this timeline
 	for _, key, kprops in utils.Children(timeline) do
 		local key_data
 
---assert(key.id == _ - 1)?
 		for _, child, cprops in utils.Children(key) do
--- assert(not key_data)
 			key_data = TimelineKey(child, cprops, object_type)
 		end
 
@@ -91,8 +95,8 @@ function M.LoadPass (timeline, animation)
 		utils.AddByID(timeline_data, key_data, kprops)
 	end
 
-	utils.AddByID(animation, timeline_data, tprops)
-end	
+  return timeline_data
+end
 
 --- DOCME
 -- @ptable data


### PR DESCRIPTION
Sorry this is one pretty big commit, and it mixes comments with new functionality and some minor clean-up.

Also, this is not by far the cleanest way to add bone support, but rather my attempt to add it to the existing code with as little code as possible. The xml format is still evolving and poorly documented and I just wanted to get things working. In short, this commit add the following:
- mainline.lua – extract bone_ref-data and save separately from object_refs.
- timeline.lua – load bones exactly the same way as objects
- entity.lua – during the Process step, build a bone_table which maps bone_ref ids to timeline ids (where the actual bone data is stored)
- object.lua – set z to 0 if it's nil (which it will be for bones); during interpolation, store the interpolated values for each bone, and apply to each bone or object farther down in the hierarchy. In other words, for each bone/object, first calculate its interpolated properties, then apply the (accumulated) transform from its parent bone, using the bone_table from the previous point.
